### PR TITLE
feat: add manual query button when extension is disabled

### DIFF
--- a/extension/scholar-rank/popup.html
+++ b/extension/scholar-rank/popup.html
@@ -132,6 +132,30 @@
       color: #d93025;
     }
 
+    .manual-query-btn {
+      width: 100%;
+      margin-top: 12px;
+      padding: 10px 16px;
+      background: #1a73e8;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .manual-query-btn:hover:not(:disabled) {
+      background: #1765cc;
+    }
+
+    .manual-query-btn:disabled {
+      background: #dadce0;
+      color: #5f6368;
+      cursor: not-allowed;
+    }
+
     .footer {
       margin-top: 16px;
       padding-top: 12px;
@@ -172,6 +196,10 @@
   <div id="status" class="status enabled">
     Extension is enabled
   </div>
+
+  <button id="manualQuery" class="manual-query-btn" disabled>
+    Query All Papers
+  </button>
 
   <div class="footer">
     <a href="https://github.com/yenslife/ScholarRank" target="_blank">GitHub</a> ·

--- a/extension/scholar-rank/popup.js
+++ b/extension/scholar-rank/popup.js
@@ -3,12 +3,14 @@ const STORAGE_KEY = 'scholarRankEnabled';
 const toggleCheckbox = document.getElementById('enableToggle');
 const statusElement = document.getElementById('status');
 const resetDataButton = document.getElementById('resetData');
+const manualQueryButton = document.getElementById('manualQuery');
 
 // Load saved state
 chrome.storage.sync.get([STORAGE_KEY], (result) => {
   const isEnabled = result[STORAGE_KEY] !== false; // default to true
   toggleCheckbox.checked = isEnabled;
   updateStatus(isEnabled);
+  updateManualQueryButton(!isEnabled);
 });
 
 // Handle toggle change
@@ -20,6 +22,7 @@ toggleCheckbox.addEventListener('change', async (e) => {
 
   // Update UI
   updateStatus(isEnabled);
+  updateManualQueryButton(!isEnabled);
 
   // Notify content scripts
   const tabs = await chrome.tabs.query({ url: '*://scholar.google.com/*' });
@@ -40,25 +43,57 @@ toggleCheckbox.addEventListener('change', async (e) => {
   }
 });
 
-// Handle reset cache
-resetDataButton.addEventListener('click', async (e) => {
-  e.preventDefault();
+// Handle manual query button
+if (manualQueryButton) {
+  manualQueryButton.addEventListener('click', async (e) => {
+    e.preventDefault();
 
-  // Send message to background to clear cache
-  await chrome.runtime.sendMessage({ type: 'SCHOLAR_RANK_CLEAR_CACHE' });
+    // Visual feedback
+    const originalText = manualQueryButton.textContent;
+    manualQueryButton.textContent = 'Querying...';
+    manualQueryButton.disabled = true;
 
-  // Visual feedback
-  resetDataButton.textContent = 'Cache cleared!';
-  setTimeout(() => {
-    resetDataButton.textContent = 'Reset Cache';
-  }, 1500);
+    // Send message to content scripts to manually query all papers
+    const tabs = await chrome.tabs.query({ url: '*://scholar.google.com/*' });
+    tabs.forEach((tab) => {
+      chrome.tabs.sendMessage(tab.id, {
+        type: 'SCHOLAR_RANK_MANUAL_QUERY'
+      }).catch(() => {
+        // Ignore errors if content script not loaded
+      });
+    });
 
-  // Reload Scholar tabs
-  const tabs = await chrome.tabs.query({ url: '*://scholar.google.com/*' });
-  tabs.forEach((tab) => {
-    chrome.tabs.reload(tab.id);
+    // Reset button after 2 seconds
+    setTimeout(() => {
+      manualQueryButton.textContent = originalText;
+      manualQueryButton.disabled = false;
+      const isEnabled = toggleCheckbox.checked;
+      updateManualQueryButton(!isEnabled);
+    }, 2000);
   });
-});
+}
+
+// Handle reset cache
+if (resetDataButton) {
+  resetDataButton.addEventListener('click', async (e) => {
+    e.preventDefault();
+
+    // Send message to background to clear cache
+    await chrome.runtime.sendMessage({ type: 'SCHOLAR_RANK_CLEAR_CACHE' });
+
+    // Visual feedback
+    resetDataButton.textContent = 'Cache cleared!';
+    setTimeout(() => {
+      resetDataButton.textContent = 'Reset Cache';
+    }, 1500);
+
+    // Reload Scholar tabs
+    const tabs = await chrome.tabs.query({ url: '*://scholar.google.com/*' });
+    tabs.forEach((tab) => {
+      chrome.tabs.reload(tab.id);
+    });
+  });
+}
 
 function updateStatus(enabled) {
   if (enabled) {
@@ -67,5 +102,11 @@ function updateStatus(enabled) {
   } else {
     statusElement.textContent = 'Extension is disabled';
     statusElement.className = 'status disabled';
+  }
+}
+
+function updateManualQueryButton(shouldEnable) {
+  if (manualQueryButton) {
+    manualQueryButton.disabled = !shouldEnable;
   }
 }


### PR DESCRIPTION
- Add "Query All Papers" button in popup (only enabled when extension is off)
- Implement manual rank query trigger via popup-to-content-script messaging
- Disable auto-scan when extension is disabled to improve performance
- Allow users to query ranks on-demand without auto-loading